### PR TITLE
Safe members

### DIFF
--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -65,6 +65,7 @@ var accountsCmd = &cobra.Command{
 	Example Usage:
 	List all accounts: $ cybr accounts list
 	Get a Account details: $ cybr accounts get 234_1`,
+	Aliases: []string{"account"},
 }
 
 var listAccountsCmd = &cobra.Command{

--- a/cmd/applications.go
+++ b/cmd/applications.go
@@ -53,6 +53,7 @@ var applicationsCmd = &cobra.Command{
 	List All Applications at Root: $ cybr applications list
 	List All Applications at \Applications: $ cybr applications list -l \\Applications
 	List All Authentication Methods: $ cybr applications methods list -a AppID`,
+	Aliases: []string{"application", "app"},
 }
 
 var listApplicationsCmd = &cobra.Command{

--- a/cmd/safes.go
+++ b/cmd/safes.go
@@ -82,6 +82,7 @@ var safesCmd = &cobra.Command{
 	List All Safes: $ cybr safes list
 	List Safe Members: $ cybr safes member list -s SafeName
 	Add Safe: $ cybr safes add -s SafeName -d Description --cpm ManagingCPM --days 0`,
+	Aliases: []string{"safe"},
 }
 
 var listSafesCmd = &cobra.Command{

--- a/cmd/safes.go
+++ b/cmd/safes.go
@@ -31,6 +31,46 @@ var (
 	SafeLocation string
 	// TargetSafeName is used by the Update Safe endpoint to refer to
 	TargetSafeName string
+	// UseAccounts use account inside of safe
+	UseAccounts bool
+	// RetrieveAccounts retrieve accounts inside of safe
+	RetrieveAccounts bool
+	// ListAccounts list accounts inside of safe
+	ListAccounts bool
+	// AddAccounts add account inside of safe
+	AddAccounts bool
+	// UpdateAccountContent update account content inside of safe
+	UpdateAccountContent bool
+	// UpdateAccountProperties update account properties inside of safe
+	UpdateAccountProperties bool
+	// InitiateCPMAccountManagementOperations init a cpm account action in safe
+	InitiateCPMAccountManagementOperations bool
+	// SpecifyNextAccountContent specify next account content in safe
+	SpecifyNextAccountContent bool
+	// ManageSafe manage this safe
+	ManageSafe bool
+	// ManageSafeMembers manage members of this safe
+	ManageSafeMembers bool
+	// BackupSafe backup the safe
+	BackupSafe bool
+	// ViewAuditLog view audit logs of this safe
+	ViewAuditLog bool
+	// ViewSafeMembers view member so this safe
+	ViewSafeMembers bool
+	// AccessWithoutConfirmation access safe without confirmation
+	AccessWithoutConfirmation bool
+	// CreateFolders create folders in safe
+	CreateFolders bool
+	// DeleteFolders delete folders in safe
+	DeleteFolders bool
+	// MoveAccountsAndFolders move accounts and folders
+	MoveAccountsAndFolders bool
+	// MemberName name of the member being added to a safe
+	MemberName string
+	//SearchIn search in Vault or Domain
+	SearchIn string
+	// MembershipExpirationDate when membership will expire
+	MembershipExpirationDate string
 )
 
 var safesCmd = &cobra.Command{
@@ -70,7 +110,7 @@ var listSafesCmd = &cobra.Command{
 }
 
 var listMembersCmd = &cobra.Command{
-	Use:   "member list",
+	Use:   "list-members",
 	Short: "List all safe members on safes or specific safe",
 	Long: `List all safe members on safes or a specific safe that
 	the user logged on can read from PAS REST API.
@@ -92,6 +132,137 @@ var listMembersCmd = &cobra.Command{
 		}
 		// Pretty print returned object as JSON blob
 		prettyprint.PrintJSON(members)
+	},
+}
+
+var addMembersCmd = &cobra.Command{
+	Use:   "add-member",
+	Short: "Add a member to a safe with specific permissions",
+	Long: `This method adds an existing user as a Safe member.
+	The user who runs this web service requires Manage Safe Members permissions in the Vault.
+	
+	Example Usage:
+	$ cybr safes add-member -s SafeName -m MemberName --retrieve-account`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get config file written to local file system
+		client, err := pasapi.GetConfig()
+		if err != nil {
+			log.Fatalf("Failed to read configuration file. %s", err)
+			return
+		}
+
+		newMember := pasapi.AddSafeMemberRequest{
+			Member: pasapi.AddSafeMember{
+				MemberName:               MemberName,
+				SearchIn:                 SearchIn,
+				MembershipExpirationDate: MembershipExpirationDate,
+				Permissions: []pasapi.PermissionKeyValue{
+					pasapi.PermissionKeyValue{
+						Key:   "UseAccounts",
+						Value: UseAccounts,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "RetrieveAccounts",
+						Value: RetrieveAccounts,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "ListAccounts",
+						Value: ListAccounts,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "AddAccounts",
+						Value: AddAccounts,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "UpdateAccountContent",
+						Value: UpdateAccountContent,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "UpdateAccountProperties",
+						Value: UpdateAccountProperties,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "InitiateCPMAccountManagementOperations",
+						Value: InitiateCPMAccountManagementOperations,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "SpecifyNextAccountContent",
+						Value: SpecifyNextAccountContent,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "ManageSafe",
+						Value: ManageSafe,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "ManageSafeMembers",
+						Value: ManageSafeMembers,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "BackupSafe",
+						Value: BackupSafe,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "ViewAuditLog",
+						Value: ViewAuditLog,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "ViewSafeMembers",
+						Value: ViewSafeMembers,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "AccessWithoutConfirmation",
+						Value: AccessWithoutConfirmation,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "CreateFolders",
+						Value: CreateFolders,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "DeleteFolders",
+						Value: DeleteFolders,
+					},
+					pasapi.PermissionKeyValue{
+						Key:   "MoveAccountsAndFolders",
+						Value: MoveAccountsAndFolders,
+					},
+				},
+			},
+		}
+
+		// Add a safe with the configuration options given via CLI subcommands
+		err = client.AddSafeMember(Safe, newMember)
+		if err != nil {
+			log.Fatalf("Failed to add member '%s' to safe '%s'. %s", MemberName, Safe, err)
+			return
+		}
+		fmt.Printf("Successfully added member '%s' to safe '%s'\n", MemberName, Safe)
+	},
+}
+
+var removeMembersCmd = &cobra.Command{
+	Use:   "remove-member",
+	Short: "Remove a member from a safe",
+	Long: `This method removes a specific member from a Safe.
+	The user who runs this web service requires Manage Safe Members permissions in the Vault.
+	
+	Example Usage:
+	$ cybr safes remove-member -s SafeName -m MemberName`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get config file written to local file system
+		client, err := pasapi.GetConfig()
+		if err != nil {
+			log.Fatalf("Failed to read configuration file. %s", err)
+			return
+		}
+
+		// Add a safe with the configuration options given via CLI subcommands
+		err = client.RemoveSafeMember(Safe, MemberName)
+		if err != nil {
+			log.Fatalf("Failed to add member '%s' to safe '%s'. %s", MemberName, Safe, err)
+			return
+		}
+
+		fmt.Printf("Successfully removed member '%s' from safe '%s'\n", MemberName, Safe)
 	},
 }
 
@@ -213,10 +384,43 @@ func init() {
 	updateSafeCmd.Flags().StringVarP(&ManagingCPM, "cpm", "", "", "New managing CPM user to change to")
 	updateSafeCmd.MarkFlagRequired("target-safe")
 
+	// add-member
+	addMembersCmd.Flags().StringVarP(&Safe, "safe-name", "s", "", "Name of the safe")
+	addMembersCmd.MarkFlagRequired("safe-name")
+	addMembersCmd.Flags().StringVarP(&MemberName, "member-name", "m", "", "Name of member being added to the desired safe")
+	addMembersCmd.MarkFlagRequired("member-name")
+	addMembersCmd.Flags().StringVarP(&MemberName, "search-in", "i", "Vault", "Search in Domain or Vault")
+	addMembersCmd.Flags().StringVarP(&MembershipExpirationDate, "member-expiration-date", "e", "", "When the membership will expire")
+	addMembersCmd.Flags().BoolVar(&UseAccounts, "use-accounts", false, "Use accounts in safe")
+	addMembersCmd.Flags().BoolVar(&RetrieveAccounts, "retrieve-accounts", false, "Retrieve accounts in safe")
+	addMembersCmd.Flags().BoolVar(&ListAccounts, "list-accounts", false, "List accounts in safe")
+	addMembersCmd.Flags().BoolVar(&AddAccounts, "add-accounts", false, "Add accounts to safe")
+	addMembersCmd.Flags().BoolVar(&UpdateAccountContent, "update-account-content", false, "Update account content in safe")
+	addMembersCmd.Flags().BoolVar(&UpdateAccountProperties, "update-account-properties", false, "Update account properties in safe")
+	addMembersCmd.Flags().BoolVar(&InitiateCPMAccountManagementOperations, "init-cpm-account-managment-operations", false, "Perform cpm actions on accounts inside of safe")
+	addMembersCmd.Flags().BoolVar(&SpecifyNextAccountContent, "specify-next-account-content", false, "Specify next account's content within safe")
+	addMembersCmd.Flags().BoolVar(&ManageSafe, "manage-safe", false, "Manage the safe")
+	addMembersCmd.Flags().BoolVar(&ManageSafeMembers, "manage-safe-members", false, "Manage members of the safe")
+	addMembersCmd.Flags().BoolVar(&BackupSafe, "backup-safe", false, "Backup the safe")
+	addMembersCmd.Flags().BoolVar(&ViewAuditLog, "view-audit-log", false, "View audit log of safe")
+	addMembersCmd.Flags().BoolVar(&ViewSafeMembers, "view-safe-members", false, "View the safe members")
+	addMembersCmd.Flags().BoolVar(&AccessWithoutConfirmation, "access-content-without-confirmation", false, "Access safe content without confirmation")
+	addMembersCmd.Flags().BoolVar(&CreateFolders, "create-folders", false, "Create folders within safe")
+	addMembersCmd.Flags().BoolVar(&DeleteFolders, "delete-folders", false, "Delete folders within safe")
+	addMembersCmd.Flags().BoolVar(&MoveAccountsAndFolders, "move-accounts-and-folders", false, "Move accounts and folders")
+
+	// remove-member
+	removeMembersCmd.Flags().StringVarP(&Safe, "safe-name", "s", "", "Name of the safe")
+	removeMembersCmd.MarkFlagRequired("safe-name")
+	removeMembersCmd.Flags().StringVarP(&MemberName, "member-name", "m", "", "Name of member being removed from the safe")
+	removeMembersCmd.MarkFlagRequired("member-name")
+
 	safesCmd.AddCommand(listSafesCmd)
 	safesCmd.AddCommand(listMembersCmd)
 	safesCmd.AddCommand(addSafeCmd)
 	safesCmd.AddCommand(deleteSafeCmd)
 	safesCmd.AddCommand(updateSafeCmd)
+	safesCmd.AddCommand(addMembersCmd)
+	safesCmd.AddCommand(removeMembersCmd)
 	rootCmd.AddCommand(safesCmd)
 }

--- a/pkg/cybr/api/safes.go
+++ b/pkg/cybr/api/safes.go
@@ -81,6 +81,47 @@ func (c Client) ListSafeMembers(safeName string) (*ListSafeMembersResponse, erro
 	return &ListSafeMembersResponse, err
 }
 
+// AddSafeMemberRequest request sent for adding a member to safe with specific permissions
+type AddSafeMemberRequest struct {
+	Member AddSafeMember `json:"member"`
+}
+
+// AddSafeMember used in AddSafeMemberRequest
+type AddSafeMember struct {
+	MemberName               string               `json:"MemberName"`
+	SearchIn                 string               `json:"SearchIn"`
+	MembershipExpirationDate string               `json:"MembershipExpirationDate,omitempty"`
+	Permissions              []PermissionKeyValue `json:"Permissions,omitempty"`
+}
+
+// PermissionKeyValue used in AddSafeMember struct
+type PermissionKeyValue struct {
+	Key   string `json:"Key"`
+	Value bool   `json:"Value"`
+}
+
+// AddSafeMember Add a user or application as a member to a safe with specific permissions
+func (c Client) AddSafeMember(safeName string, addMember AddSafeMemberRequest) error {
+	url := fmt.Sprintf("%s/PasswordVault/WebServices/PIMServices.svc/Safes/%s/Members", c.BaseURL, url.QueryEscape(safeName))
+	response, err := httpJson.Post(url, c.SessionToken, addMember, c.InsecureTLS)
+	if err != nil {
+		returnedError, _ := json.Marshal(response)
+		return fmt.Errorf("Failed to add member '%s' to safe '%s'. %s. %s", addMember.Member.MemberName, safeName, string(returnedError), err)
+	}
+	return nil
+}
+
+// RemoveSafeMember Remove a member from a specific safe
+func (c Client) RemoveSafeMember(safeName string, member string) error {
+	url := fmt.Sprintf("%s/PasswordVault/WebServices/PIMServices.svc/Safes/%s/Members/%s", c.BaseURL, url.QueryEscape(safeName), url.QueryEscape(member))
+	response, err := httpJson.Delete(url, c.SessionToken, c.InsecureTLS)
+	if err != nil {
+		returnedError, _ := json.Marshal(response)
+		return fmt.Errorf("Failed to remove member '%s' from safe '%s'. %s.  %s", member, safeName, string(returnedError), err)
+	}
+	return nil
+}
+
 // AddSafeRequest contains the body of the Add Safe function's request
 type AddSafeRequest struct {
 	SafeName              string `json:"SafeName"`

--- a/pkg/cybr/api/safes_test.go
+++ b/pkg/cybr/api/safes_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/infamousjoeg/cybr-cli/pkg/cybr/api"
 	pasapi "github.com/infamousjoeg/cybr-cli/pkg/cybr/api"
 )
 
@@ -134,5 +135,111 @@ func TestRemoveSafeFail(t *testing.T) {
 	err = client.DeleteSafe(safeName)
 	if err == nil {
 		t.Errorf("Client returned successful safe deletion even though safe '%s' should not exist", safeName)
+	}
+}
+
+func TestAddRemoveSafeMemberSuccess(t *testing.T) {
+	client := pasapi.Client{
+		BaseURL:  hostname,
+		AuthType: "cyberark",
+	}
+
+	creds := pasapi.LogonRequest{
+		Username: username,
+		Password: password,
+	}
+
+	err := client.Logon(creds)
+	if err != nil {
+		t.Errorf("Failed to logon. %s", err)
+	}
+
+	safeName := "PasswordManager"
+	memberName := "test-add-member"
+
+	retrieveAccounts := pasapi.PermissionKeyValue{
+		Key:   "RetrieveAccounts",
+		Value: true,
+	}
+
+	addMember := api.AddSafeMemberRequest{
+		Member: pasapi.AddSafeMember{
+			MemberName:  memberName,
+			SearchIn:    "Vault",
+			Permissions: []pasapi.PermissionKeyValue{retrieveAccounts},
+		},
+	}
+
+	err = client.AddSafeMember(safeName, addMember)
+	if err != nil {
+		t.Errorf("Failed to add member to safe. %s", err)
+	}
+
+	err = client.RemoveSafeMember(safeName, memberName)
+	if err != nil {
+		t.Errorf("Failed to remove member from safe. %s", err)
+	}
+}
+
+func TestAddMemberInvalidMemberName(t *testing.T) {
+	client := pasapi.Client{
+		BaseURL:  hostname,
+		AuthType: "cyberark",
+	}
+
+	creds := pasapi.LogonRequest{
+		Username: username,
+		Password: password,
+	}
+
+	err := client.Logon(creds)
+	if err != nil {
+		t.Errorf("Failed to logon. %s", err)
+	}
+
+	safeName := "PasswordManager"
+	memberName := "notReal"
+
+	retrieveAccounts := pasapi.PermissionKeyValue{
+		Key:   "RetrieveAccounts",
+		Value: true,
+	}
+
+	addMember := api.AddSafeMemberRequest{
+		Member: pasapi.AddSafeMember{
+			MemberName:  memberName,
+			SearchIn:    "Vault",
+			Permissions: []pasapi.PermissionKeyValue{retrieveAccounts},
+		},
+	}
+
+	err = client.AddSafeMember(safeName, addMember)
+	if err == nil {
+		t.Errorf("Added a non-existent member. This should not happen")
+	}
+}
+
+func TestRemoveMemberInvalidMemberName(t *testing.T) {
+	client := pasapi.Client{
+		BaseURL:  hostname,
+		AuthType: "cyberark",
+	}
+
+	creds := pasapi.LogonRequest{
+		Username: username,
+		Password: password,
+	}
+
+	err := client.Logon(creds)
+	if err != nil {
+		t.Errorf("Failed to logon. %s", err)
+	}
+
+	safeName := "PasswordManager"
+	memberName := "notReal"
+
+	err = client.RemoveSafeMember(safeName, memberName)
+	if err == nil {
+		t.Errorf("Removed a non-existent member. This should not happen")
 	}
 }


### PR DESCRIPTION
- `cybr safes add-member`
- `cybr safes remove-member`
- Actions such as `safes` can be singular now. e.g. `safe` 