### PR TITLE
#70 Add auto completion tab for fish, bash, zsh and powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ $ cybr help
 
 All commands are documentated [in the docs/ directory](docs/cybr.md).
 
+## Autocomplete
+The `cybr` CLI has a `completion` command that can be used to enable autocomplete for the CLI.
+The completion command is dependant on your shell type. Currently the only shells that are supported are: bash, zsh, fish and powershell.
+
+Below is an example on how to enable `cybr` cli auto-completion from a zsh shell.
+```bash
+# enable shell completetion. Only needs to be performed once.
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# create and write the auto-completion script.
+# ${fpath[1]} '1' may be different depending on your environment.
+cybr completion zsh > "${fpath[1]}/_cybr"
+```
+
+If you are using a different shell execute the `completion` command with the `--help` flag and follow instructions for the desired shell type.
+```bash
+cybr completion --help
+```
+
 ## Example Source Code
 
 ### Logon to the PAS REST API Web Service
@@ -81,6 +100,7 @@ func main() {
 		log.Fatalf("Authentication failed. %s", errLogon)
 	}
 	fmt.Printf("Session Token:\r\n%s\r\n\r\n", token)
+}
 ```
 
 ## Testing

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(cybr completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ cybr completion bash > /etc/bash_completion.d/cybr
+  # macOS:
+  $ cybr completion bash > /usr/local/etc/bash_completion.d/cybr
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ cybr completion zsh > "${fpath[1]}/_cybr"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ cybr completion fish | source
+
+  # To load completions for each session, execute once:
+  $ cybr completion fish > ~/.config/fish/completions/cybr.fish
+
+PowerShell:
+
+  PS> cybr completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> cybr completion powershell > cybr.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletion(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
- Add auto completion to the CLI. Resolves #70 