### PR TITLE
v0.1.2-beta Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Current products supported:
 - [Install](#install)
   - [MacOS](#macos)
   - [Windows or Linux](#windows-or-linux)
+  - [AWS CloudShell](#aws-cloudshell)
   - [Install from Source](#install-from-source)
 - [Usage](#usage)
 - [Example Source Code](#example-source-code)
@@ -36,6 +37,18 @@ $ brew install cybr-cli
 ### Windows or Linux
 
 Download from the [Releases](https://github.com/infamousjoeg/cybr-cli/releases) page.
+
+
+### AWS CloudShell
+
+```shell
+mkdir -p ~/.local/bin && \
+curl --silent "https://api.github.com/repos/infamousjoeg/cybr-cli/releases/latest" |
+    grep '"tag_name":' |
+    sed -E 's/.*"([^"]+)".*/\1/' |
+    xargs -I {}  curl -o ~/.local/bin/cybr -sOL "https://github.com/infamousjoeg/cybr-cli/releases/download/"{}'/linux_cybr' && \
+chmod +x ~/.local/bin/cybr
+```
 
 ### Install from Source
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ $ cybr help
 
 All commands are documentated [in the docs/ directory](docs/cybr.md).
 
+## Autocomplete
+The `cybr` CLI has a `completion` command that can be used to enable autocomplete for the CLI.
+The completion command is dependant on your shell type. Currently the only shells that are supported are: bash, zsh, fish and powershell.
+
+Below is an example on how to enable `cybr` cli auto-completion from a zsh shell.
+```bash
+# enable shell completetion. Only needs to be performed once.
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# create and write the auto-completion script.
+# ${fpath[1]} '1' may be different depending on your environment.
+cybr completion zsh > "${fpath[1]}/_cybr"
+```
+
+If you are using a different shell execute the `completion` command with the `--help` flag and follow instructions for the desired shell type.
+```bash
+cybr completion --help
+```
+
 ## Example Source Code
 
 ### Logon to the PAS REST API Web Service
@@ -81,6 +100,7 @@ func main() {
 		log.Fatalf("Authentication failed. %s", errLogon)
 	}
 	fmt.Printf("Session Token:\r\n%s\r\n\r\n", token)
+}
 ```
 
 ## Testing

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(cybr completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ cybr completion bash > /etc/bash_completion.d/cybr
+  # macOS:
+  $ cybr completion bash > /usr/local/etc/bash_completion.d/cybr
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ cybr completion zsh > "${fpath[1]}/_cybr"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ cybr completion fish | source
+
+  # To load completions for each session, execute once:
+  $ cybr completion fish > ~/.config/fish/completions/cybr.fish
+
+PowerShell:
+
+  PS> cybr completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> cybr completion powershell > cybr.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletion(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/logon.go
+++ b/cmd/logon.go
@@ -24,6 +24,8 @@ var (
 	BaseURL string
 	// NonInteractive logon
 	NonInteractive bool
+	// ConcurrentSession allow concurrent sessions
+	ConcurrentSession bool
 )
 
 var logonCmd = &cobra.Command{
@@ -62,8 +64,9 @@ var logonCmd = &cobra.Command{
 		}
 
 		credentials := requests.Logon{
-			Username: Username,
-			Password: password,
+			Username:          Username,
+			Password:          password,
+			ConcurrentSession: ConcurrentSession,
 		}
 
 		err := client.Logon(credentials)
@@ -107,6 +110,7 @@ func init() {
 	logonCmd.Flags().StringVarP(&BaseURL, "base-url", "b", "", "Base URL to send Logon request to [https://pvwa.example.com]")
 	logonCmd.MarkFlagRequired("base-url")
 	logonCmd.Flags().BoolVar(&NonInteractive, "non-interactive", false, "If detected, will retrieve the password from the PAS_PASSWORD environment variable")
+	logonCmd.Flags().BoolVar(&ConcurrentSession, "concurrent", false, "If detected, will create a concurrent session to the PAS API")
 
 	rootCmd.AddCommand(logonCmd)
 }

--- a/cmd/logon.go
+++ b/cmd/logon.go
@@ -24,6 +24,8 @@ var (
 	BaseURL string
 	// NonInteractive logon
 	NonInteractive bool
+	// Password to logon to the PAS REST API
+	Password string
 	// ConcurrentSession allow concurrent sessions
 	ConcurrentSession bool
 )
@@ -41,6 +43,10 @@ var logonCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		password := os.Getenv("PAS_PASSWORD")
 
+		if !NonInteractive && Password != "" {
+			log.Fatalf("An error occured because --non-interactive must be provided when using --password flag")
+		}
+
 		if !NonInteractive {
 			// Get secret value from STDIN
 			fmt.Print("Enter password: ")
@@ -51,6 +57,10 @@ var logonCmd = &cobra.Command{
 					"Stdin. Exiting...")
 			}
 			password = string(byteSecretVal)
+		}
+
+		if Password != "" {
+			password = Password
 		}
 
 		if password == "" {
@@ -102,7 +112,7 @@ var logonCmd = &cobra.Command{
 }
 
 func init() {
-	logonCmd.Flags().StringVarP(&Username, "username", "u", "", "Username to logon PAS REST API using")
+	logonCmd.Flags().StringVarP(&Username, "username", "u", "", "Username to logon to PAS REST API")
 	logonCmd.MarkFlagRequired("username")
 	logonCmd.Flags().StringVarP(&AuthenticationType, "auth-type", "a", "", "Authentication method to logon using [cyberark|ldap|radius]")
 	logonCmd.MarkFlagRequired("authType")
@@ -110,6 +120,7 @@ func init() {
 	logonCmd.Flags().StringVarP(&BaseURL, "base-url", "b", "", "Base URL to send Logon request to [https://pvwa.example.com]")
 	logonCmd.MarkFlagRequired("base-url")
 	logonCmd.Flags().BoolVar(&NonInteractive, "non-interactive", false, "If detected, will retrieve the password from the PAS_PASSWORD environment variable")
+	logonCmd.Flags().StringVarP(&Password, "password", "p", "", "Password to logon to PAS REST API, only supported when using --non-interactive flag")
 	logonCmd.Flags().BoolVar(&ConcurrentSession, "concurrent", false, "If detected, will create a concurrent session to the PAS API")
 
 	rootCmd.AddCommand(logonCmd)

--- a/pkg/cybr/api/responses/getaccount.go
+++ b/pkg/cybr/api/responses/getaccount.go
@@ -12,7 +12,7 @@ type GetAccount struct {
 	PlatformID                string                  `json:"platformId"`
 	SafeName                  string                  `json:"safeName"`
 	SecretType                string                  `json:"secretType"`
-	PlatformAccountProperties map[string]interface{}  `json:"platformAccountProperties"`
+	PlatformAccountProperties map[string]string       `json:"platformAccountProperties"`
 	SecretManagement          shared.SecretManagement `json:"secretManagement"`
 	CreatedTime               int                     `json:"createdTime"`
 }

--- a/pkg/cybr/conjur/client.go
+++ b/pkg/cybr/conjur/client.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/cyberark/conjur-api-go/conjurapi"
@@ -75,11 +74,6 @@ func getClientFromEnvironmentVariable() (*conjurapi.Client, *authn.LoginPair, er
 
 	client, err := conjurapi.NewClientFromKey(config, loginPair)
 	return client, &loginPair, err
-}
-
-// GetNetRcPath returns path to the ~/.netrc file os-agnostic
-func GetNetRcPath(homeDir string) string {
-	return filepath.FromSlash(fmt.Sprintf("%s/.netrc", homeDir))
 }
 
 // GetConjurClient create conjur client and login pair for ~/.conjurrc and ~/.netrc

--- a/pkg/cybr/conjur/conjurrc.go
+++ b/pkg/cybr/conjur/conjurrc.go
@@ -71,7 +71,7 @@ func createConjurCert(certFileName string, url string) error {
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print(fmt.Sprintf("Replace certificate file '%s' [y]: ", certFileName))
 	text, _ := reader.ReadString('\n')
-	answer := strings.Replace(text, "\n", "", -1)
+	answer := strings.TrimSpace(text)
 	// overwrite file
 	if answer == "" || answer == "y" {
 		err = ioutil.WriteFile(certFileName, []byte(pemCert), 0600)
@@ -87,7 +87,7 @@ func createConjurRcFile(account string, url string, certFileName string, conjurr
 	fmt.Print("Replace ~/.conjurrc file [y]: ")
 	reader := bufio.NewReader(os.Stdin)
 	text, err := reader.ReadString('\n')
-	answer := strings.Replace(text, "\n", "", -1)
+	answer := strings.TrimSpace(text)
 
 	// overwrite ~/.conjurrc file
 	if answer == "" || answer == "y" {

--- a/pkg/cybr/conjur/conjurrc.go
+++ b/pkg/cybr/conjur/conjurrc.go
@@ -48,12 +48,14 @@ func getPem(url string) (string, error) {
 	}
 	defer conn.Close()
 
-	if len(conn.ConnectionState().PeerCertificates) != 2 {
+	if len(conn.ConnectionState().PeerCertificates) == 1 {
 		return "", fmt.Errorf("Invalid conjur url '%s'. Make sure hostname and port are correct", url)
 	}
-	pemCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: conn.ConnectionState().PeerCertificates[0].Raw}))
-	secondPemCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: conn.ConnectionState().PeerCertificates[1].Raw}))
-	pemCert = pemCert + secondPemCert
+
+	pemCert := ""
+	for _, cert := range conn.ConnectionState().PeerCertificates {
+		pemCert += string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+	}
 
 	return pemCert, err
 }

--- a/pkg/cybr/conjur/netrc.go
+++ b/pkg/cybr/conjur/netrc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -12,6 +13,11 @@ var netrcTemplate string = `machine {{ APPLIANCE_URL }}/authn
   login {{ USERNAME }}
   password {{ PASSWORD }}
 `
+
+// GetNetRcPath returns path to the ~/.conjurrc file os-agnostic
+func GetNetRcPath(homeDir string) string {
+	return filepath.FromSlash(fmt.Sprintf("%s/.netrc", homeDir))
+}
 
 // CreateNetRc create a conjur netrc file
 func CreateNetRc(username string, password string) error {
@@ -21,19 +27,19 @@ func CreateNetRc(username string, password string) error {
 		return err
 	}
 
-	conjurrcFileName := fmt.Sprintf("%s/.conjurrc", homeDir)
+	conjurrcFileName := GetConjurRcPath(homeDir)
 	url := GetURLFromConjurRc(conjurrcFileName)
 	if url == "" {
 		return fmt.Errorf("Failed to get appliance url from '%s'. Run 'cam init' to set this file", conjurrcFileName)
 	}
 
 	// create the ~/.netrc file
-	netrcFileName := fmt.Sprintf("%s/.netrc", homeDir)
+	netrcFileName := GetNetRcPath(homeDir)
 	fmt.Print("Replace ~/.netrc file [y]: ")
 	// prompt user
 	reader := bufio.NewReader(os.Stdin)
 	text, _ := reader.ReadString('\n')
-	answer := strings.Replace(text, "\n", "", -1)
+	answer := strings.TrimSpace(text)
 	if answer == "" || answer == "y" {
 		// create the ~/.netrc file
 		netrcContent := strings.Replace(netrcTemplate, "{{ USERNAME }}", username, 1)


### PR DESCRIPTION
**Added:**
- `cybr logon --concurrent` allows concurrent REST API sessions (#89)
- `cybr completion` allows for auto tab completion (#83)
- `cybr account move` allows ability to move an account from current safe to a new safe (#93)
- `cybr logon --password` allows the ability to logon non-interactively. This allows ability to logon with `cybr ccp get-account` (#92)

**Fixed**
- `cybr conjur logon` bug fixed when running on windows (#99)
- `cybr conjur logon` now allows more than 2 certificates in retrieved certificate chain (#97)

**Changed**
- `cybr conjur list` removed default limit (#102)



