### PR TITLE
Fix #117 list safes response

### DIFF
--- a/pkg/cybr/api/responses/listsafes.go
+++ b/pkg/cybr/api/responses/listsafes.go
@@ -2,7 +2,7 @@ package responses
 
 // ListSafes contains an array of all safes the current user can read
 type ListSafes struct {
-	Safes []ListSafe `json:"values"`
+	Safes []ListSafe `json:"value"`
 }
 
 // ListSafe contains the safe details of every safe the current user can read

--- a/pkg/cybr/api/responses/listsafes.go
+++ b/pkg/cybr/api/responses/listsafes.go
@@ -2,7 +2,7 @@ package responses
 
 // ListSafes contains an array of all safes the current user can read
 type ListSafes struct {
-	Safes []ListSafe `json:"Safes"`
+	Safes []ListSafe `json:"values"`
 }
 
 // ListSafe contains the safe details of every safe the current user can read


### PR DESCRIPTION
Changes `Safes` to `value` for ListSafe struct.