### PR TITLE
Update GitHub Action Workflows

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
+        goos: [linux, windows]
         goarch: [amd64, arm64]
     steps:
     - name: Checkout source code

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -35,17 +35,3 @@ jobs:
         tags: |
           nfmsjoeg/cybr-cli:${{ steps.client_version.outputs.prop }}
           nfmsjoeg/cybr-cli:latest
-    - name: Login to GitHub Container Repository
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_PAT }}
-    - name: Build and Push Docker Container to GitHub Packages
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        context: .
-        tags: |
-          infamousjoeg/cybr-cli/cybr-cli:${{ steps.client_version.outputs.prop }}
-          infamousjoeg/cybr-cli/cybr-cli:latest


### PR DESCRIPTION
- Removed building darwin binaries from release-binary workflow. The executable requires signing that cannot be done in the workflow.
- Removed ghcr.io release of container image