### PR TITLE
Fixes #161 adds stdin support for policy load

### DIFF
--- a/cmd/conjur.go
+++ b/cmd/conjur.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+const stdinErrMsg = "Failed to read from stdin."
+
 var (
 	// Account conjur account
 	Account string
@@ -236,7 +238,7 @@ var conjurAppendPolicyCmd = &cobra.Command{
 			// Read from stdin
 			policy, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				log.Fatalf("Failed to read from stdin. %s", err)
+				log.Fatalf("%s %s", stdinErrMsg, err)
 			}
 			loadPolicyPipe(PolicyBranch, string(policy), conjurapi.PolicyModePost)
 		} else {
@@ -258,7 +260,7 @@ var conjurUpdatePolicyCmd = &cobra.Command{
 			// Read from stdin
 			policy, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				log.Fatalf("Failed to read from stdin. %s", err)
+				log.Fatalf("%s %s", stdinErrMsg, err)
 			}
 			loadPolicyPipe(PolicyBranch, string(policy), conjurapi.PolicyModePut)
 		} else {
@@ -280,7 +282,7 @@ var conjurReplacePolicyCmd = &cobra.Command{
 			// Read from stdin
 			policy, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {
-				log.Fatalf("Failed to read from stdin. %s", err)
+				log.Fatalf("%s %s", stdinErrMsg, err)
 			}
 			loadPolicyPipe(PolicyBranch, string(policy), conjurapi.PolicyModePut)
 		} else {


### PR DESCRIPTION
Fixes #161 by detecting if policy is being provided via stdin. If stdin is not detected, a file is assumed to be loaded.  If file path is not present, error is returned.

Tested successfully using:

```
cybr conjur append-policy -b root << END_POLICY
- !host foo
END_POLICY
```